### PR TITLE
Potential fix for code scanning alert no. 3: Exposure of private files

### DIFF
--- a/src/commands/dev/index.ts
+++ b/src/commands/dev/index.ts
@@ -108,9 +108,10 @@ export const dev = async (cfgPath: string) => {
     logger.spinner.update('watching for changes...');
 
     // expose node_modules under /_modules so imports are same‐origin
+    // Serve only specific subdirectories or files from node_modules
     app.use(
-        '/_modules',
-        express.static(path.resolve(process.cwd(), 'node_modules')),
+        '/_modules/morphdom',
+        express.static(path.resolve(process.cwd(), 'node_modules/morphdom/dist')),
     );
 
     app.get('/index.html', (req, res, next) => {


### PR DESCRIPTION
Potential fix for [https://github.com/ragarwalll/minimalify/security/code-scanning/3](https://github.com/ragarwalll/minimalify/security/code-scanning/3)

To fix the issue, we will restrict access to only the necessary subdirectories or files within `node_modules` that are required for the application. For example, if the application uses specific libraries like `morphdom`, we will serve only the relevant files from those libraries. This ensures that sensitive information in other parts of `node_modules` is not exposed.

The changes will involve:
1. Replacing the `app.use('/_modules', express.static(...))` line with specific routes for the required libraries.
2. Ensuring that only the necessary files or directories are served.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
